### PR TITLE
only build for node 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x]
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version}}
+      - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.node-version }}
+          node-version: 12.x
       - run: npm ci
       - run: lodge deploy --if-present
         env:


### PR DESCRIPTION
no need for you to run 2 builds on every push, you'll only ever need node 12