### PR TITLE
adds bio partial everywhere

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -20,6 +20,11 @@ handlebars.registerPartial(
   "cover",
   fs.readFileSync(pwd + "/layouts/partials/cover.hbs").toString()
 );
+// Bio
+handlebars.registerPartial(
+  "bio",
+  fs.readFileSync(pwd + "/layouts/partials/bio.hbs").toString()
+);
 
 Metalsmith(pwd)
   .source("src")
@@ -47,7 +52,8 @@ Metalsmith(pwd)
       pattern: ["*/*/*html", "*/*html", "*html"],
       partials: {
         navigation: "partials/navigation",
-        cover: "partials/navigation",
+        cover: "partials/cover",
+        bio: "partials/bio"
       },
     })
   )

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -121,6 +121,11 @@ require("yargs")
         "cover",
         fs.readFileSync(pwd + "/layouts/partials/cover.hbs").toString()
       );
+      // Bio
+      handlebars.registerPartial(
+        "bio",
+        fs.readFileSync(pwd + "/layouts/partials/bio.hbs").toString()
+      );
 
       Metalsmith(pwd)
         .source("src")
@@ -148,7 +153,8 @@ require("yargs")
             pattern: ["*/*/*html", "*/*html", "*html"],
             partials: {
               navigation: "partials/navigation",
-              cover: "partials/navigation",
+              cover: "partials/cover",
+              bio: "partials/bio"
             },
           })
         )


### PR DESCRIPTION
seems like this duplicated code could use some abstractions! try to see if you can remove all of these definitions and have a single `lib.js` or something that does all of the Metalsmith setup for you so you can import it and not duplicate all the code in your different scripts