### PR TITLE
fix: make lodge throw errors properly

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -54,7 +54,7 @@ Metalsmith(pwd)
 
   .build(function (err) {
     if (err) {
-      console.error(err);
+      throw err
     } else {
       console.log("build completed!");
     }

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -87,7 +87,7 @@ require("yargs")
         )
         .build(function (err) {
           if (err) {
-            console.error(err);
+            throw err
           } else {
             console.log("build completed!");
           }
@@ -155,7 +155,7 @@ require("yargs")
 
         .build(function (err) {
           if (err) {
-            console.error(err);
+            throw err
           } else {
             console.log("build completed!");
           }

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -77,7 +77,7 @@ Metalsmith(pwd)
   )
   .build(function (err) {
     if (err) {
-      console.error(err);
+      throw err
     } else {
       console.log("build completed!");
     }


### PR DESCRIPTION
i'd recommend playing around with `echo $?` to learn a bit about exit codes, but this change does the trick to make CI provide you with error codes if they occur in `lodge`